### PR TITLE
Fix RSS dates

### DIFF
--- a/source/_templates/rss.xml
+++ b/source/_templates/rss.xml
@@ -9,12 +9,12 @@
 		<title>roadtolarissa</title>
 		<link>https://roadtolarissa.com</link>
 	</image>
-	${d.filter(post => post.meta.draft != 'true').map(post => 
+	${d.filter(post => post.meta.draft != 'true').reverse().map(post => 
 		`
 		<item>
 			<title>${post.meta.title}</title>
 			<link>https://roadtolarissa.com${post.meta.permalink}</link>
-			<pubDate>${post.date}</pubDate>
+			<pubDate>${(new Date(post.date)).toUTCString()}</pubDate>
 		</item>
 		`
 	).join('')}


### PR DESCRIPTION
Hi! Dates/ordering weren't working properly in my RSS reader, and I guess [your current date formatting doesn't meet the RSS spec](https://validator.w3.org/feed/docs/error/InvalidRFC2822Date.html). `.toUTCString()` seems to [make it work](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString#Description).

I also reversed the order of posts so the RSS feed will list them in reverse chronological order. This isn't strictly necessary, but [it may make things work better in some readers](https://stackoverflow.com/questions/1830580/rss-items-order-does-it-matter).